### PR TITLE
fix: store setTimeout locally in case it was overriden

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,11 +43,6 @@ export interface EventOptions<Remote> {
   timeout?: number
 
   /**
-   * Timeout implementation in case global timeout is not reliable.
-   */
-  setTimeout?: typeof globalThis.setTimeout
-
-  /**
    * Custom resolver to resolve function to be called
    *
    * For advanced use cases only
@@ -140,6 +135,9 @@ export const DEFAULT_TIMEOUT = 60_000 // 1 minute
 const defaultSerialize = (i: any) => i
 const defaultDeserialize = defaultSerialize
 
+// store setTimeout locally in case it is overriden later
+const { setTimeout } = globalThis
+
 export function createBirpc<RemoteFunctions = {}, LocalFunctions = {}>(
   functions: LocalFunctions,
   options: BirpcOptions<RemoteFunctions>,
@@ -151,7 +149,6 @@ export function createBirpc<RemoteFunctions = {}, LocalFunctions = {}>(
     serialize = defaultSerialize,
     deserialize = defaultDeserialize,
     resolver,
-    setTimeout = globalThis.setTimeout,
     timeout = DEFAULT_TIMEOUT,
   } = options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,11 @@ export interface EventOptions<Remote> {
   timeout?: number
 
   /**
+   * Timeout implementation in case global timeout is not reliable.
+   */
+  setTimeout?: typeof globalThis.setTimeout
+
+  /**
    * Custom resolver to resolve function to be called
    *
    * For advanced use cases only
@@ -146,6 +151,7 @@ export function createBirpc<RemoteFunctions = {}, LocalFunctions = {}>(
     serialize = defaultSerialize,
     deserialize = defaultDeserialize,
     resolver,
+    setTimeout = globalThis.setTimeout,
     timeout = DEFAULT_TIMEOUT,
   } = options
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR stores `setTimeout` locally in case it was overridden later by a mocked one.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

None.

### Additional context

This is needed, so we can remove the ugly Proxy in Vitest that stopped working after birpc allowed async `on`.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Alternative

We can also take `setTimeout` from `globalThis` in the module context