### PR TITLE
fix: store `Math.random` locally to prevent overriding it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,8 +137,9 @@ function defaultSerialize(i: any) {
 }
 const defaultDeserialize = defaultSerialize
 
-// store setTimeout locally in case it is overriden later
+// Store public APIs locally in case they are overriden later
 const { setTimeout } = globalThis
+const random = Math.random.bind(Math)
 
 export function createBirpc<RemoteFunctions = {}, LocalFunctions = {}>(
   functions: LocalFunctions,
@@ -297,6 +298,6 @@ function nanoid(size = 21) {
   let id = ''
   let i = size
   while (i--)
-    id += urlAlphabet[(Math.random() * 64) | 0]
+    id += urlAlphabet[(random() * 64) | 0]
   return id
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Store `Math.random` locally during module initialization. In Vitest if users mock `Math.random` and do not restore it correctly, Vitest will simply freeze and `birpc` timeouts.

### Linked Issues

- https://github.com/vitest-dev/vitest/discussions/3457#discussioncomment-6021760

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I also checked all other public APIs and don't think there are any other APIs that need such handling. 