### PR TITLE
fix: store `clearTimeout` locally to prevent overriding it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ function defaultSerialize(i: any) {
 const defaultDeserialize = defaultSerialize
 
 // Store public APIs locally in case they are overridden later
-const { setTimeout } = globalThis
+const { clearTimeout, setTimeout } = globalThis
 const random = Math.random.bind(Math)
 
 export function createBirpc<RemoteFunctions = Record<string, never>, LocalFunctions = Record<string, never>>(


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Stores `clearTimeout` locally in case someone overwrites the global one during runtime.

### Linked Issues

Similar as https://github.com/antfu/birpc/pull/7 and https://github.com/antfu/birpc/pull/8. Introduced in https://github.com/antfu/birpc/pull/10. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
