### PR TITLE
fix: timeoutId compatible for browser-like environments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,9 +201,8 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
             }, timeout)
 
             // For node.js, `unref` is not available in browser-like environments
-            if (typeof timeoutId === 'object') {
+            if (typeof timeoutId === 'object')
               timeoutId = timeoutId.unref?.()
-            }
           }
 
           rpcPromiseMap.set(id, { resolve, reject, timeoutId })

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
     timeout = DEFAULT_TIMEOUT,
   } = options
 
-  const rpcPromiseMap = new Map<string, { resolve: (arg: any) => void, reject: (error: any) => void, timeoutId: Parameters<typeof clearTimeout>[0] }>()
+  const rpcPromiseMap = new Map<string, { resolve: (arg: any) => void, reject: (error: any) => void, timeoutId?: ReturnType<typeof setTimeout> }>()
 
   let _promise: Promise<any> | any
 
@@ -185,7 +185,7 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
         await _promise
         return new Promise((resolve, reject) => {
           const id = nanoid()
-          let timeoutId
+          let timeoutId: ReturnType<typeof setTimeout> | undefined
 
           if (timeout >= 0) {
             timeoutId = setTimeout(() => {
@@ -198,7 +198,12 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
                 reject(e)
               }
               rpcPromiseMap.delete(id)
-            }, timeout).unref?.()
+            }, timeout)
+
+            // For node.js, `unref` is not available in browser-like environments
+            if (typeof timeoutId === 'object') {
+              timeoutId = timeoutId.unref?.()
+            }
           }
 
           rpcPromiseMap.set(id, { resolve, reject, timeoutId })


### PR DESCRIPTION
Fixes `timeoutId` being undefined when trying to call unref in browser-like environments.

### Linked Issues

fix #15
