### PR TITLE
feat: support async iter as rpc result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -259,7 +259,7 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
           result = await fn.apply(rpc, args)
 
           // handle async iter result
-          if (result[Symbol.asyncIterator]) {
+          if (result?.[Symbol.asyncIterator]) {
             for await (const iterRes of result) {
               if (msg.i)
                 post(serialize(<Response>{ t: 's', i: msg.i, r: iterRes, d: false, e: error }), ...extra)

--- a/test/alice.ts
+++ b/test/alice.ts
@@ -1,3 +1,36 @@
+import { ReadableStream } from 'node:stream/web'
+
 export function hello(name: string) {
   return `Hello ${name}, my name is Alice`
+}
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+export async function* helloAsyncGenerator(name: string) {
+  yield `Hello ${name}, my name is Alice`
+  await sleep(50)
+  yield `Hello ${name}, my name is Alice`
+  await sleep(50)
+  yield `Hello ${name}, my name is Alice`
+}
+
+export async function* helloAsyncError(name: string) {
+  yield `Hello ${name}, my name is Alice`
+  await sleep(50)
+  yield `Hello ${name}, my name is Alice`
+  await sleep(50)
+  throw new Error('Oops, something went wrong!')
+}
+
+export function helloStream(name: string) {
+  return new ReadableStream<string>({
+    async start(controller) {
+      controller.enqueue(`Hello ${name}, my name is Alice`)
+      await sleep(50)
+      controller.enqueue(`Hello ${name}, my name is Alice`)
+      await sleep(50)
+      controller.enqueue(`Hello ${name}, my name is Alice`)
+      controller.close()
+    },
+  })
 }

--- a/test/async-iter.test.ts
+++ b/test/async-iter.test.ts
@@ -1,0 +1,87 @@
+import { MessageChannel } from 'node:worker_threads'
+import { expect, it } from 'vitest'
+import { createBirpc } from '../src'
+import * as Bob from './bob'
+import * as Alice from './alice'
+
+type BobFunctions = typeof Bob
+type AliceFunctions = typeof Alice
+
+function createChannel() {
+  const channel = new MessageChannel()
+  return {
+    channel,
+    alice: createBirpc<BobFunctions, AliceFunctions>(
+      Alice,
+      {
+        // mark bob's `bump` as an event without response
+        eventNames: ['bump'],
+        post: data => channel.port2.postMessage(data),
+        on: fn => channel.port2.on('message', fn),
+      },
+    ),
+    bob: createBirpc<AliceFunctions, BobFunctions>(
+      Bob,
+      {
+        post: data => channel.port1.postMessage(data),
+        on: fn => channel.port1.on('message', fn),
+      },
+    ),
+  }
+}
+
+async function toArray<T>(iter: AsyncIterable<T>) {
+  const arr = []
+  for await (const i of iter) arr.push(i)
+  return arr as T[]
+}
+
+it('async generator', async () => {
+  const { bob } = createChannel()
+
+  const iter = bob.helloAsyncGenerator.asAsyncIter('Bob')
+
+  const arr = await toArray(iter)
+
+  expect(arr).toEqual([
+    'Hello Bob, my name is Alice',
+    'Hello Bob, my name is Alice',
+    'Hello Bob, my name is Alice',
+  ])
+})
+
+it('async generator err', async () => {
+  const { bob } = createChannel()
+
+  const iter = bob.helloAsyncError.asAsyncIter('Bob')
+
+  const arr = []
+  let error: any
+  try {
+    for await (const i of iter)
+      arr.push(i)
+  }
+  catch (err) {
+    error = err
+  }
+
+  expect(arr).toEqual([
+    'Hello Bob, my name is Alice',
+    'Hello Bob, my name is Alice',
+  ])
+  expect(error).toMatchInlineSnapshot(`[Error: Oops, something went wrong!]`)
+})
+
+it('async readable stream', async () => {
+  const { bob } = createChannel()
+
+  const iter = bob.helloStream.asAsyncIter('Bob')
+
+  const arr = await toArray(iter)
+
+  expect(arr).toEqual([
+    'Hello Bob, my name is Alice',
+    'Hello Bob, my name is Alice',
+    'Hello Bob, my name is Alice',
+  ])
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently, birpc can only handle result of rpc calling once, that make it hard to handle streaming multiple results (e.g. ReadableStream, Async Generator).

This pr check if fn result has `Symbol.asyncIterator`, if ture, post the result sequencially and consume it on the other side.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
