### PR TITLE
feat: introduce $close method and `bind` option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,9 +208,13 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
           throw new Error(`[birpc] rpc is closed, cannot call "${method}"`)
         if (_promise) {
           // Wait if `on` is promise
-          await _promise.finally(() => {
+          try {
+            await _promise
+          }
+          finally {
+            // don't keep resolved promise hanging
             _promise = undefined
-          })
+          }
         }
         return new Promise((resolve, reject) => {
           const id = nanoid()

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,16 +181,8 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
       if (method === '$functions')
         return functions
 
-      if (method === '$close') {
-        return () => {
-          closed = true
-          rpcPromiseMap.forEach(({ reject }) => {
-            reject(new Error('[birpc] rpc is closed'))
-          })
-          rpcPromiseMap.clear()
-          off(onMessage)
-        }
-      }
+      if (method === '$close')
+        return close
 
       // catch if "createBirpc" is returned from async function
       if (method === 'then' && !eventNames.includes('then' as any) && !('then' in functions))
@@ -246,6 +238,15 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
       return sendCall
     },
   }) as BirpcReturn<RemoteFunctions, LocalFunctions>
+
+  function close() {
+    closed = true
+    rpcPromiseMap.forEach(({ reject }) => {
+      reject(new Error('[birpc] rpc is closed'))
+    })
+    rpcPromiseMap.clear()
+    off(onMessage)
+  }
 
   async function onMessage(data: any, ...extra: any[]) {
     const msg = deserialize(data) as RPCMessage

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,10 @@ export interface ChannelOptions {
    */
   on: (fn: (data: any, ...extras: any[]) => void) => any | Promise<any>
   /**
+   * Clear the listener when `$close` is called
+   */
+  off?: (fn: (data: any, ...extras: any[]) => void) => any | Promise<any>
+  /**
    * Custom function to serialize data
    *
    * by default it passes the data as-is
@@ -27,6 +31,11 @@ export interface ChannelOptions {
    * by default it passes the data as-is
    */
   deserialize?: (data: any) => any
+
+  /**
+   * Call the methods with the RPC context or the original functions object
+   */
+  bind?: 'rpc' | 'functions'
 }
 
 export interface EventOptions<Remote> {
@@ -82,7 +91,7 @@ export interface BirpcGroupFn<T> {
 
 export type BirpcReturn<RemoteFunctions, LocalFunctions = Record<string, never>> = {
   [K in keyof RemoteFunctions]: BirpcFn<RemoteFunctions[K]>
-} & { $functions: LocalFunctions }
+} & { $functions: LocalFunctions, $close: () => void }
 
 export type BirpcGroupReturn<RemoteFunctions> = {
   [K in keyof RemoteFunctions]: BirpcGroupFn<RemoteFunctions[K]>
@@ -153,21 +162,35 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
   const {
     post,
     on,
+    off = () => {},
     eventNames = [],
     serialize = defaultSerialize,
     deserialize = defaultDeserialize,
     resolver,
+    bind = 'rpc',
     timeout = DEFAULT_TIMEOUT,
   } = options
 
   const rpcPromiseMap = new Map<string, { resolve: (arg: any) => void, reject: (error: any) => void, timeoutId?: ReturnType<typeof setTimeout> }>()
 
   let _promise: Promise<any> | any
+  let closed = false
 
   const rpc = new Proxy({}, {
     get(_, method: string) {
       if (method === '$functions')
         return functions
+
+      if (method === '$close') {
+        return () => {
+          closed = true
+          rpcPromiseMap.forEach(({ reject }) => {
+            reject(new Error('[birpc] rpc is closed'))
+          })
+          rpcPromiseMap.clear()
+          off(onMessage)
+        }
+      }
 
       // catch if "createBirpc" is returned from async function
       if (method === 'then' && !eventNames.includes('then' as any) && !('then' in functions))
@@ -181,8 +204,14 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
         return sendEvent
       }
       const sendCall = async (...args: any[]) => {
-        // Wait if `on` is promise
-        await _promise
+        if (closed)
+          throw new Error(`[birpc] rpc is closed, cannot call "${method}"`)
+        if (_promise) {
+          // Wait if `on` is promise
+          await _promise.finally(() => {
+            _promise = undefined
+          })
+        }
         return new Promise((resolve, reject) => {
           const id = nanoid()
           let timeoutId: ReturnType<typeof setTimeout> | undefined
@@ -214,7 +243,7 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
     },
   }) as BirpcReturn<RemoteFunctions, LocalFunctions>
 
-  _promise = on(async (data, ...extra) => {
+  async function onMessage(data: any, ...extra: any[]) {
     const msg = deserialize(data) as RPCMessage
     if (msg.t === 'q') {
       const { m: method, a: args } = msg
@@ -228,7 +257,7 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
       }
       else {
         try {
-          result = await fn.apply(rpc, args)
+          result = await fn.apply(bind === 'rpc' ? rpc : functions, args)
         }
         catch (e) {
           error = e
@@ -254,7 +283,9 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
       }
       rpcPromiseMap.delete(ack)
     }
-  })
+  }
+
+  _promise = on(onMessage)
 
   return rpc
 }

--- a/test/close.test.ts
+++ b/test/close.test.ts
@@ -1,0 +1,24 @@
+import { nextTick } from 'node:process'
+import { expect, it } from 'vitest'
+import { createBirpc } from '../src'
+
+it('stops the rpc promises', async () => {
+  const rpc = createBirpc<{ hello: () => string }>({}, {
+    on() {},
+    post() {},
+  })
+  const promise = rpc.hello().then(
+    () => {
+      throw new Error('Promise should not resolve')
+    },
+    (err) => {
+      // Promise should reject
+      expect(err.message).toBe('[birpc] rpc is closed')
+    },
+  )
+  nextTick(() => {
+    rpc.$close()
+  })
+  await promise
+  await expect(() => rpc.hello()).rejects.toThrow('[birpc] rpc is closed, cannot call "hello"')
+})

--- a/test/close.test.ts
+++ b/test/close.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from 'vitest'
 import { createBirpc } from '../src'
 
 it('stops the rpc promises', async () => {
+  expect.assertions(2)
   const rpc = createBirpc<{ hello: () => string }>({}, {
     on() {},
     post() {},


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR addresses two issues I have with the current implementation:

- The context is lost when I pass down an instance of a class (I don't actually want methods inside to reference each other as rpc calls): https://github.com/vitest-dev/vscode/blob/61b37b9ca6b0415d1c511c3e836bd5f92ba2df67/src/worker/worker.ts#L35
- There is no native way to stop the promise if the connection has been lost/disconnected, which leads to an infinite promise if the timeout is disabled (needed in Vitest for debugger support). This PR adds a `$close` method that works similarly to the abort controller (will throw an error in pending promises) - should we use the abort controller instead?

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
