### PR TITLE
fix: improve the error message when close is called

### DIFF
--- a/test/close.test.ts
+++ b/test/close.test.ts
@@ -14,7 +14,7 @@ it('stops the rpc promises', async () => {
     },
     (err) => {
       // Promise should reject
-      expect(err.message).toBe('[birpc] rpc is closed')
+      expect(err.message).toBe('[birpc] rpc is closed, cannot call "hello"')
     },
   )
   nextTick(() => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The `reject` is called without a method, so it's hard to know which method throw an error if you didn't catch it

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
