### PR TITLE
feat: allow custom errors in `$close`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ export interface BirpcGroupFn<T> {
 
 export type BirpcReturn<RemoteFunctions, LocalFunctions = Record<string, never>> = {
   [K in keyof RemoteFunctions]: BirpcFn<RemoteFunctions[K]>
-} & { $functions: LocalFunctions, $close: () => void }
+} & { $functions: LocalFunctions, $close: (error?: Error) => void }
 
 export type BirpcGroupReturn<RemoteFunctions> = {
   [K in keyof RemoteFunctions]: BirpcGroupFn<RemoteFunctions[K]>
@@ -266,10 +266,10 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
     },
   }) as BirpcReturn<RemoteFunctions, LocalFunctions>
 
-  function close() {
+  function close(error?: Error) {
     closed = true
     rpcPromiseMap.forEach(({ reject, method }) => {
-      reject(new Error(`[birpc] rpc is closed, cannot call "${method}"`))
+      reject(error || new Error(`[birpc] rpc is closed, cannot call "${method}"`))
     })
     rpcPromiseMap.clear()
     off(onMessage)

--- a/test/close.test.ts
+++ b/test/close.test.ts
@@ -23,3 +23,24 @@ it('stops the rpc promises', async () => {
   await promise
   await expect(() => rpc.hello()).rejects.toThrow('[birpc] rpc is closed, cannot call "hello"')
 })
+
+it('stops the rpc promises with a custom message', async () => {
+  expect.assertions(1)
+  const rpc = createBirpc<{ hello: () => string }>({}, {
+    on() {},
+    post() {},
+  })
+  const promise = rpc.hello().then(
+    () => {
+      throw new Error('Promise should not resolve')
+    },
+    (err) => {
+      // Promise should reject
+      expect(err.message).toBe('Custom error')
+    },
+  )
+  nextTick(() => {
+    rpc.$close(new Error('Custom error'))
+  })
+  await promise
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This is useful when we need to stop any ongoing message with a specific message. It's possible that message is different depending on why we closed the RPC.

In Vitest, I am planning to have a unique message when the page in browser mode closes down unexpectedly. 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
