### PR TITLE
fix: `$close` to set original error in `.cause`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -269,10 +269,17 @@ export function createBirpc<RemoteFunctions = Record<string, never>, LocalFuncti
     },
   }) as BirpcReturn<RemoteFunctions, LocalFunctions>
 
-  function close(error?: Error) {
+  function close(customError?: Error) {
     closed = true
     rpcPromiseMap.forEach(({ reject, method }) => {
-      reject(error || new Error(`[birpc] rpc is closed, cannot call "${method}"`))
+      const error = new Error(`[birpc] rpc is closed, cannot call "${method}"`)
+
+      if (customError) {
+        customError.cause ??= error
+        return reject(customError)
+      }
+
+      reject(error)
     })
     rpcPromiseMap.clear()
     off(onMessage)

--- a/test/close.test.ts
+++ b/test/close.test.ts
@@ -25,7 +25,7 @@ it('stops the rpc promises', async () => {
 })
 
 it('stops the rpc promises with a custom message', async () => {
-  expect.assertions(1)
+  expect.assertions(2)
   const rpc = createBirpc<{ hello: () => string }>({}, {
     on() {},
     post() {},
@@ -37,10 +37,39 @@ it('stops the rpc promises with a custom message', async () => {
     (err) => {
       // Promise should reject
       expect(err.message).toBe('Custom error')
+
+      // Original error should be present
+      expect(err.cause.message).toBe('[birpc] rpc is closed, cannot call "hello"')
     },
   )
   nextTick(() => {
     rpc.$close(new Error('Custom error'))
+  })
+  await promise
+})
+
+it('custom error\'s cause is not overwritten', async () => {
+  expect.assertions(2)
+  const rpc = createBirpc<{ hello: () => string }>({}, {
+    on() {},
+    post() {},
+  })
+  const promise = rpc.hello().then(
+    () => {
+      throw new Error('Promise should not resolve')
+    },
+    (err) => {
+      // Promise should reject
+      expect(err.message).toBe('Custom error')
+
+      // Custom error cause should be present
+      expect(err.cause.message).toBe('Custom cause')
+    },
+  )
+  nextTick(() => {
+    const error = new Error('Custom error')
+    error.cause = new Error('Custom cause')
+    rpc.$close(error)
   })
   await promise
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- When user providers custom `Error` in `$close`, attach birpc's internal error in its `.cause`.
- Allows users to provider custom descriptive errors while preserving birpcs internal `method` in the error message

### Linked Issues

- Related to https://github.com/vitest-dev/vitest/issues/8164

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
