### PR TITLE
feat: add `$rejectPendingCalls`

### DIFF
--- a/test/reject-pending-calls.test.ts
+++ b/test/reject-pending-calls.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from 'vitest'
+import { createBirpc } from '../src'
+
+it('rejects pending calls', async () => {
+  const rpc = createBirpc<{ first: () => Promise<void>, second: () => Promise<void> }>({}, {
+    on() {},
+    post() {},
+  })
+
+  const promises = [
+    rpc.first()
+      .then(() => expect.fail('first() should not resolve'))
+      .catch(error => error),
+
+    rpc.second()
+      .then(() => expect.fail('second() should not resolve'))
+      .catch(error => error),
+  ]
+
+  const rejections = rpc.$rejectPendingCalls(({ method, reject }) =>
+    reject(new Error(`Rejected call. Method: "${method}".`)),
+  )
+  expect(rejections).toHaveLength(2)
+
+  const errors = await Promise.all(promises)
+  expect(errors).toHaveLength(2)
+
+  expect.soft(errors[0].message).toBe('Rejected call. Method: "first".')
+  expect.soft(errors[1].message).toBe('Rejected call. Method: "second".')
+})
+
+it('rejected calls are cleared from rpc', async () => {
+  const rpc = createBirpc<{ stuck: () => Promise<void> }>({}, {
+    on() {},
+    post() {},
+  })
+
+  rpc.stuck()
+    .then(() => expect.fail('stuck() should not resolve'))
+    .catch(() => undefined)
+
+  {
+    const rejections = rpc.$rejectPendingCalls(({ reject }) => reject(new Error('Rejected')))
+    expect(rejections).toHaveLength(1)
+  }
+
+  {
+    const rejections = rpc.$rejectPendingCalls(({ reject }) => reject(new Error('Rejected')))
+    expect(rejections).toHaveLength(0)
+  }
+})

--- a/test/reject-pending-calls.test.ts
+++ b/test/reject-pending-calls.test.ts
@@ -17,6 +17,32 @@ it('rejects pending calls', async () => {
       .catch(error => error),
   ]
 
+  const rejections = rpc.$rejectPendingCalls()
+  expect(rejections).toHaveLength(2)
+
+  const errors = await Promise.all(promises)
+  expect(errors).toHaveLength(2)
+
+  expect.soft(errors[0].message).toBe('[birpc]: rejected pending call "first".')
+  expect.soft(errors[1].message).toBe('[birpc]: rejected pending call "second".')
+})
+
+it('rejects pending calls with custom handler', async () => {
+  const rpc = createBirpc<{ first: () => Promise<void>, second: () => Promise<void> }>({}, {
+    on() {},
+    post() {},
+  })
+
+  const promises = [
+    rpc.first()
+      .then(() => expect.fail('first() should not resolve'))
+      .catch(error => error),
+
+    rpc.second()
+      .then(() => expect.fail('second() should not resolve'))
+      .catch(error => error),
+  ]
+
   const rejections = rpc.$rejectPendingCalls(({ method, reject }) =>
     reject(new Error(`Rejected call. Method: "${method}".`)),
   )


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
On Vitest we need to reject pending methods on Worker side. While `rpc.$close` does this perfectly, we cannot use it. We are using the rpc channel for transferring the rejected methods, so `$close` is closing the channel before rejection are sent to main thread.

This PR adds new method that can be used to explicitly reject the pending methods.

### Linked Issues
- Related to https://github.com/vitest-dev/vitest/issues/8164

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
